### PR TITLE
fix: endpoints related hotfix and other minor issues

### DIFF
--- a/app/components/UI/MovieCard/MovieCard.styles.js
+++ b/app/components/UI/MovieCard/MovieCard.styles.js
@@ -21,10 +21,6 @@ export const Wrapper = styled(flexDivStyle)`
   flex-direction: column;
   align-items: flex-start;
 
-  /* &:hover {
-    opacity: 0.8;
-  } */
-
   &:hover ${PosterWrapper} {
     opacity: 0.8;
   }

--- a/app/components/UI/MoviePoster/index.js
+++ b/app/components/UI/MoviePoster/index.js
@@ -12,7 +12,7 @@ export default function MoviePoster({ src, alt, title, ...props }) {
       objectFit={'cover'}
       objectPosition={'50% 50%'}
       placeholder={'blur'}
-      blurDataURL={'public/images/placeholder-blur.png'}
+      blurDataURL={'images/placeholder-blur.png'}
       {...props}
     />
   );

--- a/lib/services/movieDb.js
+++ b/lib/services/movieDb.js
@@ -106,7 +106,7 @@ export async function getListOfPopularMovies() {
  * @param {string|number} id Id of the movie to get a list of similar movies
  * @return {Promise<Object|null>}  movie object
  */
-export async function getSimilarMoviesById(id) {
+export async function getListOfSimilarMoviesById(id) {
   return movieDbClient(`movie/${id}/similar`);
 }
 
@@ -117,6 +117,6 @@ export async function getSimilarMoviesById(id) {
  * @param {string|number} id Id of the movie to get a list of recommended movies
  * @return {Promise<Object|null>}  movie object
  */
-export async function getRecommendedMoviesById(id) {
+export async function getListOfRecommendedMoviesById(id) {
   return movieDbClient(`movie/${id}/recommendations`);
 }

--- a/pages/api/movies/[id]/recommendations.js
+++ b/pages/api/movies/[id]/recommendations.js
@@ -1,4 +1,4 @@
-import { getRecommendedMoviesById } from '../../../../lib/services/movieDb';
+import { getListOfRecommendedMoviesById } from '../../../../lib/services/movieDb';
 
 /**
  * @swagger
@@ -24,11 +24,11 @@ import { getRecommendedMoviesById } from '../../../../lib/services/movieDb';
 export default async function handler(req, res) {
   try {
     const { id } = req.query;
-    const movies = await getRecommendedMoviesById(id);
+    const movies = await getListOfRecommendedMoviesById(id);
     if (!movies) {
       return res.status(404).json();
     }
-    return res.status(200).json(movies);
+    return res.status(200).json(movies.results);
   } catch (e) {
     const message = e.response ? await e.response.text() : e.message;
     return res.status(400).json(message);

--- a/pages/api/movies/[id]/similar.js
+++ b/pages/api/movies/[id]/similar.js
@@ -1,4 +1,4 @@
-import { getSimilarMoviesById } from '../../../../lib/services/movieDb';
+import { getListOfSimilarMoviesById } from '../../../../lib/services/movieDb';
 
 /**
  * @swagger
@@ -24,11 +24,11 @@ import { getSimilarMoviesById } from '../../../../lib/services/movieDb';
 export default async function handler(req, res) {
   try {
     const { id } = req.query;
-    const movies = await getSimilarMoviesById(id);
+    const movies = await getListOfSimilarMoviesById(id);
     if (!movies) {
       return res.status(404).json();
     }
-    return res.status(200).json(movies);
+    return res.status(200).json(movies.results);
   } catch (e) {
     const message = e.response ? await e.response.text() : e.message;
     return res.status(400).json(message);


### PR DESCRIPTION
Guys, realized that I forgot about one **important** and several minor things and made following changes:

- **endpoints** have now `return res.status(200).json(movies.results);` since we want array of movies, without information about number of pages and number of results. Furthermore, lack of `.results` led to problems inside `services/movieDb.js`,
- function names inside `services/movieDb.js` have now more fitting names,
- MoviePoster's `blurDataURL` is without `public/` prefix now. This led to localhost not using this image to blur MoviePoster on load,
- some other small changes.